### PR TITLE
fix mobile overflow issue

### DIFF
--- a/src/components/Headings.jsx
+++ b/src/components/Headings.jsx
@@ -1,21 +1,18 @@
-import styled from 'styled-components';
+import styled from "styled-components"
 
-const H1 = styled.h1` 
+const H1 = styled.h1`
   font-size: 2.5em;
   text-align: center;
   align-self: center;
   margin-bottom: 10px;
   margin: 15px 0 0 0;
-`;
+`
 
 const H2 = styled.h2`
   font-size: 1.5em;
   text-align: center;
   align-self: center;
   margin-bottom: 10px;
-`;
+`
 
-export {
-  H1,
-  H2
-}
+export { H1, H2 }

--- a/src/components/RecipePageStyling.jsx
+++ b/src/components/RecipePageStyling.jsx
@@ -2,14 +2,13 @@ import { H1 } from "./Headings"
 import styled from "styled-components"
 
 const Wrapper = styled.div`
-  display: flex;
   flex-direction: column;
   display: grid;
   justify-items: center;
   align-items: baseline;
   padding: 2em 15px 10px 15px;
   /* padding-bottom: 25px; */
-  width: 100%;
+  width: 100vw;
   grid-template-columns: 1fr;
   grid-template-areas:
     "title"
@@ -128,8 +127,6 @@ const IngredientsBox = styled(InfoBox)`
     max-height: 90vh;
     /* margin: 15px auto; */
 
-
-
     .ingredients-box-title {
       position: -webkit-sticky;
       position: sticky;
@@ -166,6 +163,7 @@ const StepsBox = styled(InfoBox)`
   @media (min-width: 760px) {
     /* border-left: 2px dashed black; */
     padding-left: 20px;
+    padding-right: 20px;
     justify-self: left;
   }
   .sidenote {


### PR DESCRIPTION
the width of the recipe page was overflowing on mobile, by changing width from `100%` to `100vw` of the parent wrapper, the issue is fixed